### PR TITLE
Update gatsby-config.js

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -10,7 +10,7 @@ module.exports = {
       options: {
         repository: {
           baseUrl: 'https://github.com/carbon-design-system/carbon-for-ibm-website',
-          branch: 'master',
+          subDirectory: '',
         },
       },
     },

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -4,5 +4,15 @@ module.exports = {
     description: 'This is the Carbon for IBM.com website, which includes documentation and guidelines around design and development for IBM.com',
     keywords: 'gatsby,theme,carbon,ibm',
   },
-  plugins: ['gatsby-theme-carbon'],
+  plugins: [
+    {
+      resolve: 'gatsby-theme-carbon',
+      options: {
+        repository: {
+          baseUrl: 'https://github.com/carbon-design-system/carbon-for-ibm-website',
+          branch: 'master',
+        },
+      },
+    },
+  ],
 };


### PR DESCRIPTION
### Related Ticket(s)

No related issues

### Description

This adds in the optional url for editing the current page in Github. Instructions were taken from here:

https://gatsby-theme-carbon.now.sh/guides/configuration/#edit-on-github-link

### Changelog

**Changed**

- Changed gatsby config file
